### PR TITLE
Put message

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -263,7 +263,27 @@ exports.postMessage = function(req, res) {
   );
 }
 
-//Need to add a put message
+exports.putMessageByRecipient = function(req, res) {
+  var user = req.body.recipient;
+
+  console.log('user', user);
+  Message.find({'recipient': user}, function(err, messages) {
+    if (err) {
+      res.statsus(500).send(err);
+    } else {
+      messages.forEach(function(message) {
+        message.read = true;
+        message.save(function (err, todo) {
+          if (err) {
+            res.staus(500).send(err);
+          } else {
+            res.status(200).send();
+          }
+        });
+      });
+    }
+  });
+};
 
 //adding filtering logic
 var getRating = function(buddyRequestId, username, callback) {

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -280,7 +280,6 @@ var getRating = function(buddyRequestId, username, callback) {
   });
 };
 
-
 //keep, but not exposed
 var getUserAverageRating = function(username) {
   /*

--- a/public/components/app.jsx
+++ b/public/components/app.jsx
@@ -1,9 +1,6 @@
 class App extends React.Component {
   constructor(props) {
     super(props);
-    // this.state = {
-    //   selectSearch: true
-    // };
     this.state = {
       userName: '',
       render: {
@@ -29,7 +26,6 @@ class App extends React.Component {
       url: 'http://localhost:3000/user',
       type: 'GET',
       success: function(user) {
-        console.log('user', user);
         self.setState(() => ({userName: user}));
       }
     })
@@ -40,7 +36,6 @@ class App extends React.Component {
   }
 
   getMessages() {
-    console.log('this.state.userName', this.state.userName);
     if (this.state.userName.length) {
       $.ajax({
         type: 'GET',

--- a/public/components/app.jsx
+++ b/public/components/app.jsx
@@ -14,28 +14,49 @@ class App extends React.Component {
         renderResults: false,
         renderPost: false
       },
-      selectedNotification: {}
+      selectedNotification: {},
+      messages: []
     };
+    this.getMessages = this.getMessages.bind(this);
     this.handleNotificationSelect = this.handleNotificationSelect.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
   }
 
-  componentWillMount(){
+  componentDidMount(){
     var self = this;
 
     $.ajax({
       url: 'http://localhost:3000/user',
-      type: 'GET'
+      type: 'GET',
+      success: function(user) {
+        console.log('user', user);
+        self.setState(() => ({userName: user}));
+      }
     })
-    .done(function(user) {
-      console.log('RESPONSE', user)
-      self.setState({
-        userName: user
-      });
-    })
+    .done(() => (this.getMessages()))
     .fail(function(err) {
       console.log('ERROR', err)
-    })
+    });
+  }
+
+  getMessages() {
+    console.log('this.state.userName', this.state.userName);
+    if (this.state.userName.length) {
+      $.ajax({
+        type: 'GET',
+        url: 'http://localhost:3000/message/recipient',
+        data: {recipient: this.state.userName},
+        success: function(messages) {
+          this.setState({
+            messages: messages
+          });
+        }.bind(this),
+        error: function(err) {
+          console.log('Couldn\'t get messages:', err)
+        }
+      });
+    }
+    setTimeout(this.getMessages, 3000);
   }
 
   handleNotificationSelect(notification){
@@ -103,10 +124,12 @@ class App extends React.Component {
         />
         <div className="dynamicContent col-md-9">
           <DynamicContent
+            handleNotificationSelect={this.handleNotificationSelect}
             render={this.state.render}
             handleSelect={this.handleSelect}
             user={this.state.userName}
             selectedNotification={this.state.selectedNotification}
+            messages={this.state.messages}
           />
         </div>
         <div className="notificationWindow col-md-3">
@@ -114,6 +137,7 @@ class App extends React.Component {
             handleNotificationSelect={this.handleNotificationSelect}
             handleSelect={this.handleSelect}
             user={this.state.userName}
+            messages={this.state.messages}
           />
         </div>
       </div>

--- a/public/components/dynamic-content.jsx
+++ b/public/components/dynamic-content.jsx
@@ -7,16 +7,8 @@ class DynamicContent extends React.Component {
       results: [],
       currentPost: ''
     };
-    this.messages = [];
     this.handleSubmitRequest = this.handleSubmitRequest.bind(this);
     this.handlePostClick = this.handlePostClick.bind(this);
-    this.getMessages = this.getMessages.bind(this);
-  }
-
-  //This runs every time set state runs, so messages should not be part of state
-    //or else this will spam the server
-  componentDidUpdate(){
-    this.getMessages();
   }
 
   handleSubmitRequest(data) {
@@ -35,22 +27,6 @@ class DynamicContent extends React.Component {
     this.setState({
       currentPost: post,
     });
-  }
-
-  getMessages() {
-    if (this.props.user !== '') {
-      $.ajax({
-        type: 'GET',
-        url: 'http://localhost:3000/message/recipient',
-        data: {recipient: this.props.user},
-        success: function(messages) {
-          this.messages = messages;
-        }.bind(this),
-        error: function(err) {
-          console.log('Couldn\'t get messages:', err)
-        }
-      });
-    }
   }
 
   render() {
@@ -107,9 +83,10 @@ class DynamicContent extends React.Component {
         <div className="componentWindow">
           <h1>Messages</h1>
           <MessageList
+            handleNotificationSelect={this.props.handleNotificationSelect}
             selectedNotification={this.props.selectedNotification}
             user={this.props.user}
-            messages={this.messages}
+            messages={this.props.messages}
           />
         </div>
       );

--- a/public/components/message.jsx
+++ b/public/components/message.jsx
@@ -1,5 +1,5 @@
 var Message = ({message, handleMessageClick}) => (
- <tr onClick={() => handleMessageClick(message.sender)} className="row-select">
+ <tr onClick={() => handleMessageClick(message)} className="row-select">
   <td>{message.sender}</td>
   <td>{message.message}</td>
  </tr>

--- a/public/components/messageList.jsx
+++ b/public/components/messageList.jsx
@@ -2,7 +2,6 @@ class MessageList extends React.Component {
   constructor(props){
     super(props);
     this.state = {
-      messages: this.props.messages,
       recipient: ''
     };
     this.handleMessageClick = this.handleMessageClick.bind(this);
@@ -17,10 +16,21 @@ class MessageList extends React.Component {
     //Perform ajax put request
   }
 
-  handleMessageClick(recipient){
+  //This allows the recipient of the users message to be changed when a notification is clicked
+    //while the user is viewing messages
+  //https://stackoverflow.com/questions/32414308/updating-state-on-props-change-in-react-form
+  componentWillReceiveProps(nextProps) {
+    // You don't have to do this check first, but it can help prevent an unneeded render
+    if (nextProps.selectedNotification.sender !== this.state.recipient) {
+      this.setState({ recipient: nextProps.selectedNotification.sender });
+    }
+  }
+
+  handleMessageClick(message){
     this.setState({
-      recipient: recipient
+      recipient: message.sender
     });
+    this.props.handleNotificationSelect(message);
   };
 
   render(){
@@ -35,7 +45,7 @@ class MessageList extends React.Component {
               </thead>
               <tbody>
                 {
-                  this.state.messages.map((message) =>
+                  this.props.messages.map((message) =>
                     <Message
                       message={message}
                       handleMessageClick={this.handleMessageClick}

--- a/public/components/messageList.jsx
+++ b/public/components/messageList.jsx
@@ -2,27 +2,57 @@ class MessageList extends React.Component {
   constructor(props){
     super(props);
     this.state = {
-      recipient: ''
+      recipient: '',
+      messages: []
     };
     this.handleMessageClick = this.handleMessageClick.bind(this);
+    this.updateMessagesAsRead = this.updateMessagesAsRead.bind(this);
   }
 
   componentDidMount () {
+    var isRead = true;
+
     if (this.props.selectedNotification.sender) {
       this.setState({
         recipient: this.props.selectedNotification.sender
       });
     }
-    //Perform ajax put request
+    for (var i = 0; i < this.props.messages.length; i++) {
+      if (this.props.messages[i].read === false) {
+        isRead = false;
+        break;
+      }
+    }
+    //Prevents the put request from being called if the messages have
+      //already been updated as read
+    if (isRead === false) {
+      this.updateMessagesAsRead();
+    }
   }
 
   //This allows the recipient of the users message to be changed when a notification is clicked
     //while the user is viewing messages
   //https://stackoverflow.com/questions/32414308/updating-state-on-props-change-in-react-form
   componentWillReceiveProps(nextProps) {
+    var isRead = true;
+
     // You don't have to do this check first, but it can help prevent an unneeded render
     if (nextProps.selectedNotification.sender !== this.state.recipient) {
       this.setState({ recipient: nextProps.selectedNotification.sender });
+    }
+    if ((nextProps.messages.length !== this.props.messages.length) ||
+      (JSON.stringify(nextProps.messages) !== JSON.stringify(this.props.messages))) {
+      for (var i = 0; i < nextProps.messages.length; i++) {
+        if (nextProps.messages[i].read === false) {
+          isRead = false;
+          break;
+        }
+      }
+      //Prevents the put request from being called twice, once because the messages
+        //changed and once because the messages read property changed from true to false
+      if (isRead === false) {
+        this.updateMessagesAsRead();
+      }
     }
   }
 
@@ -31,7 +61,21 @@ class MessageList extends React.Component {
       recipient: message.sender
     });
     this.props.handleNotificationSelect(message);
-  };
+  }
+
+  updateMessagesAsRead(){
+    $.ajax({
+      type: 'PUT',
+      url: 'http://localhost:3000/message/recipient',
+      data: {recipient: this.props.user},
+      success: function() {
+        console.log('PUT request succeeded!')
+      }.bind(this),
+      error: function(err) {
+        console.log('PUT request failed!')
+      }
+    });
+  }
 
   render(){
     return (
@@ -57,7 +101,7 @@ class MessageList extends React.Component {
         <SendMessage recipient={this.state.recipient} sender={this.props.user}/>
       </div>
     );
-  };
+  }
 }
 
 window.MessageList = MessageList;

--- a/public/components/notifications.jsx
+++ b/public/components/notifications.jsx
@@ -2,37 +2,13 @@ class Notifications extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      notifications: [],
     };
     this.handleClick = this.handleClick.bind(this);
-    this.getNotifications = this.getNotifications.bind(this);
-  }
-
-  componentDidMount() {
-    this.getNotifications();
   }
 
   handleClick(notification) {
     this.props.handleNotificationSelect(notification);
     this.props.handleSelect('selectMessages');
-    //Perform ajax put request
-  }
-
-  getNotifications() {
-    $.ajax({
-      type: 'GET',
-      url: 'http://localhost:3000/message/recipient',
-      data: {recipient: this.props.user},
-      success: function(messages) {
-        this.setState({
-          notifications: messages,
-        });
-      }.bind(this),
-      error: function(err) {
-        console.log('Couldn\'t get notifications:', err)
-      }
-    });
-    setTimeout(this.getNotifications, 3000);
   }
 
   render() {
@@ -40,7 +16,7 @@ class Notifications extends React.Component {
       <div className="noitifications">
         <h2>Notifications</h2>
         <aside>
-          {this.state.notifications.map(notification => {
+          {this.props.messages.map(notification => {
             if (notification.read === false) {
               return <NotificationMessage key={notification._id} notification={notification} handleClick={this.handleClick} />
             }

--- a/public/components/send-message.jsx
+++ b/public/components/send-message.jsx
@@ -28,7 +28,7 @@ class SendMessage extends React.Component {
 
     if (this.state.message === '') {
       console.log('Please type a message');
-    } else if (this.recipient === '') {
+    } else if ((this.recipient === undefined) || (this.recipient === '')) {
       console.log('Please select a recipient')
     } else {
       $.ajax({

--- a/server-config.js
+++ b/server-config.js
@@ -61,8 +61,7 @@ app.post('/buddyRequest', handler.postBuddyRequest);
 app.get('/message', handler.getMessages);
 app.get('/message/recipient', handler.getMessagesByRecipient);
 app.post('/message', handler.postMessage);
-//need put routes ie.:
-//app.put('/message', hanlder.putMessage);
+app.put('/message/recipient', handler.putMessageByRecipient);
 
 // app.get('/rating', handler.getRating);
 app.get('/rating/:request_id', handler.getRequestRatings);


### PR DESCRIPTION
Messages are now pulled from the server in app and passed down to message list and notifications from props, clicking on a message or a notification updates the receiver, removed a new line from request handler

Wrote put request handler for read messages, message list updates the messages read property only when there is a new unread message, send message will not allow the user to send a message unless a recipient has been chosen, removed some test prints from app

Fixes #91 
Closes #46 